### PR TITLE
Add IFA landing page

### DIFF
--- a/infatech-nextjs/src/app/Components/Ifa/FaqIfa.jsx
+++ b/infatech-nextjs/src/app/Components/Ifa/FaqIfa.jsx
@@ -34,7 +34,10 @@ const FaqIfa = ({ faqs }) => {
         <div className="row">
           <div className="col-lg-6 col-md-12">
             <div className="section-title text-left">
-              <SectionTitle SubTitle="FAQs" Title="Common <span>Questions</span>" />
+              <SectionTitle
+                SubTitle="client review"
+                Title="Frequently Asked <span> Question?</span>"
+              />
             </div>
             <div className="tab_container">
               <div id="tab1" className="tab_content">

--- a/infatech-nextjs/src/app/Components/Ifa/FaqIfa.jsx
+++ b/infatech-nextjs/src/app/Components/Ifa/FaqIfa.jsx
@@ -1,0 +1,63 @@
+"use client";
+import { useEffect, useRef, useState } from 'react';
+import SectionTitle from '../Common/SectionTitle';
+import loadBackgroudImages from '../Common/loadBackgroudImages';
+import Image from 'next/image';
+
+const FaqIfa = ({ faqs }) => {
+  const accordionContentRef = useRef(null);
+  const [openItemIndex, setOpenItemIndex] = useState(-1);
+  const [firstItemOpen, setFirstItemOpen] = useState(true);
+
+  const handleItemClick = index => {
+    if (index === openItemIndex) {
+      setOpenItemIndex(-1);
+    } else {
+      setOpenItemIndex(index);
+    }
+  };
+
+  useEffect(() => {
+    if (firstItemOpen) {
+      setOpenItemIndex(0);
+      setFirstItemOpen(false);
+    }
+  }, [firstItemOpen]);
+
+  useEffect(() => {
+    loadBackgroudImages();
+  }, []);
+
+  return (
+    <div className="faq-area style-two" data-background="/assets/images/home-3/faq-bg.png">
+      <div className="container">
+        <div className="row">
+          <div className="col-lg-6 col-md-12">
+            <div className="section-title text-left">
+              <SectionTitle SubTitle="FAQs" Title="Common <span>Questions</span>" />
+            </div>
+            <div className="tab_container">
+              <div id="tab1" className="tab_content">
+                <ul className="accordion">
+                  {faqs.map((item, index) => (
+                    <li key={index} className={`cs_accordian ${index === openItemIndex ? 'active' : ''}`}>
+                      <a onClick={() => handleItemClick(index)}><span>{item.q}</span></a>
+                      <p ref={accordionContentRef}>{item.a}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div className="col-lg-6 col-md-12">
+            <div className="faq-thumb faq_thumb_area mt -5">
+              <Image src="/assets/images/home-3/faq-thumb.png" alt="faq" width={700} height={782} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FaqIfa;

--- a/infatech-nextjs/src/app/Components/Ifa/IfaFeatures.jsx
+++ b/infatech-nextjs/src/app/Components/Ifa/IfaFeatures.jsx
@@ -1,0 +1,34 @@
+"use client";
+import Image from 'next/image';
+import SectionTitle from '../Common/SectionTitle';
+
+const IfaFeatures = ({ features }) => {
+  return (
+    <div className="feature-area">
+      <div className="container">
+        <div className="row about align-items-center">
+          <div className="col-lg-12">
+            <div className="section-title text-center">
+              <SectionTitle SubTitle="WHAT'S INCLUDED" Title="Key Features" />
+            </div>
+          </div>
+          {features.map((item, i) => (
+            <div key={i} className="col-xl-3 col-lg-4 col-md-6">
+              <div className="feature-sinble-single-box">
+                <div className="feature-icon">
+                  <Image src={item.icon} alt="icon" width={36} height={36} />
+                </div>
+                <div className="feature-content">
+                  <h3 className="feature-title">{item.title}</h3>
+                  <p className="feature-text">{item.desc}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default IfaFeatures;

--- a/infatech-nextjs/src/app/ifa-website/layout.jsx
+++ b/infatech-nextjs/src/app/ifa-website/layout.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import HeaderStyle3 from '../Components/Header/HeaderStyle3';
+import Footer from '../Components/Footer/Footer';
+
+const layout = ({ children }) => {
+    return (
+        <div className='main-page-area3'>
+            <HeaderStyle3></HeaderStyle3>
+            {children}
+            <Footer></Footer>
+        </div>
+    );
+};
+
+export default layout;

--- a/infatech-nextjs/src/app/ifa-website/page.jsx
+++ b/infatech-nextjs/src/app/ifa-website/page.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import Link from 'next/link';
+
+const LandingPage = () => {
+  return (
+    <main className="ifa-landing-page">
+      {/* Offer Section */}
+      <section className="py-5 bg-light text-center">
+        <div className="container">
+          <h1 className="display-5 fw-bold mb-4">Your Own Professional Advisor Website — Live in Just 7 Days</h1>
+          <p className="lead">We handle everything for Indian IFAs: domain, hosting, design, stock ticker, calculators, WhatsApp chat, and more — all done for you at a transparent price.</p>
+        </div>
+      </section>
+
+      {/* What's Included */}
+      <section className="py-5">
+        <div className="container">
+          <h2 className="mb-4">What&apos;s Included</h2>
+          <ul className="list-unstyled">
+            <li className="mb-2">✔️ Custom Domain &amp; Hosting — no extra billing.</li>
+            <li className="mb-2">✔️ 5 Professional Designs to choose from.</li>
+            <li className="mb-2">✔️ 5 Must-Have Pages: Home, About, Services, Resources, Contact.</li>
+            <li className="mb-2">✔️ Resources page with live stock ticker, finance news, SIP/EMI calculators and downloads.</li>
+            <li className="mb-2">✔️ WhatsApp &amp; Email Integration.</li>
+            <li className="mb-2">✔️ Free SSL Security Certificate.</li>
+            <li className="mb-2">✔️ Basic SEO Setup.</li>
+            <li className="mb-2">✔️ Fully Managed Setup &amp; Maintenance.</li>
+          </ul>
+        </div>
+      </section>
+
+      {/* FAQ Section */}
+      <section className="py-5 bg-light">
+        <div className="container">
+          <h2 className="mb-4">Frequently Asked Questions</h2>
+          <div className="mb-3">
+            <strong>Is the domain cost included?</strong>
+            <p>Yes. We purchase and manage your domain for you — it&apos;s included in your annual fee.</p>
+          </div>
+          <div className="mb-3">
+            <strong>Do I have to do anything technical?</strong>
+            <p>No. Just choose a design, send your info, and we handle the rest.</p>
+          </div>
+          <div className="mb-3">
+            <strong>How long will it take?</strong>
+            <p>Your site will go live in 7 days from receiving your details.</p>
+          </div>
+          <div className="mb-3">
+            <strong>Will my site show up on Google?</strong>
+            <p>Yes — we set up basic SEO so your site is searchable.</p>
+          </div>
+          <div className="mb-3">
+            <strong>What does the annual renewal cover?</strong>
+            <p>Domain, hosting, SSL certificate, security checks and up to two minor content edits per year.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing & CTA */}
+      <section className="py-5 text-center">
+        <div className="container">
+          <h2 className="mb-3">One Simple Price, No Surprises</h2>
+          <p className="fs-4 mb-2">One-Time Setup Fee: ₹7,000</p>
+          <p className="fs-5 mb-4">Annual Renewal: ₹1,500/year</p>
+          <Link href="https://wa.me/" className="btn btn-primary btn-lg">Chat with Us on WhatsApp</Link>
+        </div>
+      </section>
+    </main>
+  );
+};
+
+export default LandingPage;

--- a/infatech-nextjs/src/app/ifa-website/page.jsx
+++ b/infatech-nextjs/src/app/ifa-website/page.jsx
@@ -1,72 +1,71 @@
 import React from 'react';
 import Link from 'next/link';
+import Hero2 from '../Components/Banner/Hero2';
+import PricingCard from '../Components/Pricing/PricingCard';
+import Contact1 from '../Components/Contact/Contact1';
+import IfaFeatures from '../Components/Ifa/IfaFeatures';
+import FaqIfa from '../Components/Ifa/FaqIfa';
 
-const LandingPage = () => {
+const features = [
+  { icon: '/assets/images/service1.png', title: 'Domain & Hosting', desc: 'We register your domain and handle secure hosting.' },
+  { icon: '/assets/images/service2.png', title: 'Modern Templates', desc: 'Choose from 5 clean, mobile-friendly designs.' },
+  { icon: '/assets/images/service3.png', title: 'Resources Tools', desc: 'Live stock ticker, news feed and handy calculators.' },
+  { icon: '/assets/images/service4.png', title: 'Easy Contact', desc: 'WhatsApp chat and simple enquiry form built-in.' },
+];
+
+const faqs = [
+  { q: 'Is the domain cost included?', a: 'Yes. We purchase and manage your domain for you.' },
+  { q: 'Do I need technical skills?', a: 'No. Our team sets everything up for you.' },
+  { q: 'How long does it take?', a: 'Your site will be live within 7 days of receiving your info.' },
+  { q: 'What does renewal cover?', a: 'Domain, hosting, SSL, security checks and minor text edits.' },
+];
+
+const Page = () => {
   return (
-    <main className="ifa-landing-page">
-      {/* Offer Section */}
-      <section className="py-5 bg-light text-center">
-        <div className="container">
-          <h1 className="display-5 fw-bold mb-4">Your Own Professional Advisor Website — Live in Just 7 Days</h1>
-          <p className="lead">We handle everything for Indian IFAs: domain, hosting, design, stock ticker, calculators, WhatsApp chat, and more — all done for you at a transparent price.</p>
-        </div>
-      </section>
+    <div className='ifa-landing-page'>
+      <Hero2
+        bgImg='/assets/images/hero-bg.png'
+        SubTitle='IFA WEBSITE STARTER PACK'
+        Title='Launch Your Advisor Website in <br> 7 Days'
+        Content='Domain, hosting, design and live market tools – all managed for you.'
+        BtnText='Chat on WhatsApp'
+        BtnLink='https://wa.me/'
+        mainImage='/assets/images/hero-thumb.png'
+      />
 
-      {/* What's Included */}
-      <section className="py-5">
-        <div className="container">
-          <h2 className="mb-4">What&apos;s Included</h2>
-          <ul className="list-unstyled">
-            <li className="mb-2">✔️ Custom Domain &amp; Hosting — no extra billing.</li>
-            <li className="mb-2">✔️ 5 Professional Designs to choose from.</li>
-            <li className="mb-2">✔️ 5 Must-Have Pages: Home, About, Services, Resources, Contact.</li>
-            <li className="mb-2">✔️ Resources page with live stock ticker, finance news, SIP/EMI calculators and downloads.</li>
-            <li className="mb-2">✔️ WhatsApp &amp; Email Integration.</li>
-            <li className="mb-2">✔️ Free SSL Security Certificate.</li>
-            <li className="mb-2">✔️ Basic SEO Setup.</li>
-            <li className="mb-2">✔️ Fully Managed Setup &amp; Maintenance.</li>
-          </ul>
-        </div>
-      </section>
+      <IfaFeatures features={features} />
 
-      {/* FAQ Section */}
-      <section className="py-5 bg-light">
-        <div className="container">
-          <h2 className="mb-4">Frequently Asked Questions</h2>
-          <div className="mb-3">
-            <strong>Is the domain cost included?</strong>
-            <p>Yes. We purchase and manage your domain for you — it&apos;s included in your annual fee.</p>
-          </div>
-          <div className="mb-3">
-            <strong>Do I have to do anything technical?</strong>
-            <p>No. Just choose a design, send your info, and we handle the rest.</p>
-          </div>
-          <div className="mb-3">
-            <strong>How long will it take?</strong>
-            <p>Your site will go live in 7 days from receiving your details.</p>
-          </div>
-          <div className="mb-3">
-            <strong>Will my site show up on Google?</strong>
-            <p>Yes — we set up basic SEO so your site is searchable.</p>
-          </div>
-          <div className="mb-3">
-            <strong>What does the annual renewal cover?</strong>
-            <p>Domain, hosting, SSL certificate, security checks and up to two minor content edits per year.</p>
+      <section className='pricing-area'>
+        <div className='container'>
+          <div className='row justify-content-center'>
+            <div className='col-md-6 col-lg-4'>
+              <PricingCard
+                Price='₹7,000'
+                PricePlan='One-Time Setup'
+                BtnUrl='https://wa.me/'
+                BtnText='Get Started'
+                FeatureList={[
+                  'Custom Domain & Hosting',
+                  '5 Page Website',
+                  'Live Stock Tools',
+                  'WhatsApp Integration',
+                  'Go Live in 7 Days',
+                ]}
+              />
+            </div>
           </div>
         </div>
       </section>
 
-      {/* Pricing & CTA */}
-      <section className="py-5 text-center">
-        <div className="container">
-          <h2 className="mb-3">One Simple Price, No Surprises</h2>
-          <p className="fs-4 mb-2">One-Time Setup Fee: ₹7,000</p>
-          <p className="fs-5 mb-4">Annual Renewal: ₹1,500/year</p>
-          <Link href="https://wa.me/" className="btn btn-primary btn-lg">Chat with Us on WhatsApp</Link>
-        </div>
+      <FaqIfa faqs={faqs} />
+
+      <section className='text-center py-5'>
+        <Link href='https://wa.me/' className='btn btn-primary btn-lg'>Chat with Us on WhatsApp</Link>
       </section>
-    </main>
+
+      <Contact1 />
+    </div>
   );
 };
 
-export default LandingPage;
+export default Page;


### PR DESCRIPTION
## Summary
- create basic landing page for IFA Website Starter Pack
- include new layout for the route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f591e538832d8670ea51ee4c2dfa